### PR TITLE
fix __post_init__ bug

### DIFF
--- a/quri_algo/circuit/time_evolution/exact_unitary.py
+++ b/quri_algo/circuit/time_evolution/exact_unitary.py
@@ -8,6 +8,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from typing import cast
 
 import numpy as np
@@ -24,6 +25,7 @@ from quri_algo.circuit.utils.transpile import apply_transpiler
 from quri_algo.problem.hamiltonian import QubitHamiltonianInput
 
 
+@dataclass
 class ExactUnitaryTimeEvolutionCircuitFactory(
     ProblemCircuitFactory[QubitHamiltonianInput]
 ):
@@ -49,6 +51,7 @@ class ExactUnitaryTimeEvolutionCircuitFactory(
         return circuit
 
 
+@dataclass
 class ExactUnitaryControlledTimeEvolutionCircuitFactory(
     ControlledTimeEvolutionCircuitFactory[QubitHamiltonianInput]
 ):


### PR DESCRIPTION
## Issue

The exact time evolution circuit factories failed to run the `__post_init__` method that stored a numpy array version of the Hamiltonian input

## Changes

The bug was fixed by using the `@dataclass` decorator

## Progress

- [x] Main implementation written
- [x] Functions as intended
- ~[ ] Unit tests have been written~
- ~[ ] readme.md has been updated~